### PR TITLE
ZMODEM is disabled by default

### DIFF
--- a/rflan/src/app_cli.c
+++ b/rflan/src/app_cli.c
@@ -70,19 +70,6 @@ static char             AppCliCmdBuf[ APP_CLI_CMD_BUF_SIZE ];
 static CliCmd_t const  *AppCliCmdList[ APP_CLI_CMD_LIST_SIZE ];
 static XUartPs          AppCliUart;
 
-void outubyte(u8 c)
-{
-	if(AppCliTxCharQueue != NULL)
-	{
-		BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-		/* Send Byte to Tx Queue */
-		xQueueSendFromISR( AppCliTxCharQueue, &c, &xHigherPriorityTaskWoken );
-
-		portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-	}
-}
-
 void outbyte(char c)
 {
 	if(AppCliTxCharQueue != NULL)

--- a/rflan/src/zmodem/zmodem.c
+++ b/rflan/src/zmodem/zmodem.c
@@ -37,7 +37,7 @@ typedef struct
 
 static ZMODEM_CTRL zmodem_ctrl;                             // The ZMODEM control block (external)
 
-extern void outubyte(u8 c);
+extern void outbyte(char c);
 
 //--------------------------------------------------------------------------
 // Function:    ZModem_Write
@@ -52,7 +52,7 @@ extern void outubyte(u8 c);
 static SHORT ZModem_Write(UBYTE data)
 {
   if (zmodem_ctrl.ready && zmodem_ctrl.run)
-    outubyte(data);
+    outbyte(data);
 
   return (0);
 }

--- a/rflan/src/zmodem/zmodem.c
+++ b/rflan/src/zmodem/zmodem.c
@@ -24,6 +24,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include "xil_types.h"
+#include "xil_printf.h"
 #include "zmodem_pub.h"
 #include "app_cli.h"
 
@@ -100,19 +101,11 @@ static void ZModem_CliZmodem(Cli_t *CliInstance, const char *cmd, void *userData
   {
     zmodem_ctrl.run = 1;
     zModemInit(&zmodem_ctrl.instance, ZModem_Write, NULL);
-
-    xil_printf("\r\n");
-    xil_printf("done\r\n");
-    xil_printf("\r\n");
   }
   else if (strcmp(operation, "disable") == 0)
   {
     zmodem_ctrl.run = 0;
     zModemInit(&zmodem_ctrl.instance, ZModem_Write, NULL);
-
-    xil_printf("\r\n");
-    xil_printf("done\r\n");
-    xil_printf("\r\n");
   }
   else if (strcmp(operation, "status") == 0)
   {
@@ -168,7 +161,7 @@ int ZModem_Initialize(char *drive)
     if (Cli_RegisterCommand(Instance, &ZModemCliDef) == 0)
     {
       RetVal = 0; // Success;
-      zmodem_ctrl.run = 1;
+      zmodem_ctrl.run = 0;
       zmodem_ctrl.ready = 1;
     }
   }

--- a/rflan/src/zmodem/zmodem.c
+++ b/rflan/src/zmodem/zmodem.c
@@ -121,10 +121,12 @@ static void ZModem_CliZmodem(Cli_t *CliInstance, const char *cmd, void *userData
     xil_printf("-------------------------------\r\n");
     xil_printf("Module state         : %s\r\n", (zmodem_ctrl.run ? "enabled(1)" : "disabled(0)"));
     xil_printf("Last operation \r\n");
-    xil_printf("    file name        : %s\r\n", zmodem_ctrl.instance.Stats.FileName);
+    xil_printf("    file name        : %s\r\n",  zmodem_ctrl.instance.Stats.FileName);
     xil_printf("    file size        : %ld\r\n", zmodem_ctrl.instance.Stats.FileSize);
     xil_printf("    file read count  : %ld\r\n", zmodem_ctrl.instance.Stats.FileRead);
     xil_printf("    file write count : %ld\r\n", zmodem_ctrl.instance.Stats.FileWrite);
+    xil_printf("    size of ctrl     : %ld\r\n", sizeof(ZMODEM_CTRL));   
+    xil_printf("    size of inst     : %ld\r\n", sizeof(ZMODEM_INSTANCE));   
     xil_printf("\r\n");
   }
   else
@@ -133,7 +135,6 @@ static void ZModem_CliZmodem(Cli_t *CliInstance, const char *cmd, void *userData
     xil_printf("unknown command\r\n");
     xil_printf("\r\n");
   }
-
 }
 
 static const CliCmd_t ZModemCliDef =

--- a/rflan/src/zmodem/zmodem.c
+++ b/rflan/src/zmodem/zmodem.c
@@ -101,37 +101,37 @@ static void ZModem_CliZmodem(Cli_t *CliInstance, const char *cmd, void *userData
     zmodem_ctrl.run = 1;
     zModemInit(&zmodem_ctrl.instance, ZModem_Write, NULL);
 
-    printf("\r\n");
-    printf("done\r\n");
-    printf("\r\n");
+    xil_printf("\r\n");
+    xil_printf("done\r\n");
+    xil_printf("\r\n");
   }
   else if (strcmp(operation, "disable") == 0)
   {
     zmodem_ctrl.run = 0;
     zModemInit(&zmodem_ctrl.instance, ZModem_Write, NULL);
 
-    printf("\r\n");
-    printf("done\r\n");
-    printf("\r\n");
+    xil_printf("\r\n");
+    xil_printf("done\r\n");
+    xil_printf("\r\n");
   }
   else if (strcmp(operation, "status") == 0)
   {
-    printf("-------------------------------\r\n");
-    printf("            ZMODEM             \r\n");
-    printf("-------------------------------\r\n");
-    printf("Module state         : %s\r\n", (zmodem_ctrl.run ? "enabled(1)" : "disabled(0)"));
-    printf("Last operation \r\n");
-    printf("    file name        : %s\r\n", zmodem_ctrl.instance.Stats.FileName);
-    printf("    file size        : %ld\r\n", zmodem_ctrl.instance.Stats.FileSize);
-    printf("    file read count  : %ld\r\n", zmodem_ctrl.instance.Stats.FileRead);
-    printf("    file write count : %ld\r\n", zmodem_ctrl.instance.Stats.FileWrite);
-    printf("\r\n");
+    xil_printf("-------------------------------\r\n");
+    xil_printf("            ZMODEM             \r\n");
+    xil_printf("-------------------------------\r\n");
+    xil_printf("Module state         : %s\r\n", (zmodem_ctrl.run ? "enabled(1)" : "disabled(0)"));
+    xil_printf("Last operation \r\n");
+    xil_printf("    file name        : %s\r\n", zmodem_ctrl.instance.Stats.FileName);
+    xil_printf("    file size        : %ld\r\n", zmodem_ctrl.instance.Stats.FileSize);
+    xil_printf("    file read count  : %ld\r\n", zmodem_ctrl.instance.Stats.FileRead);
+    xil_printf("    file write count : %ld\r\n", zmodem_ctrl.instance.Stats.FileWrite);
+    xil_printf("\r\n");
   }
   else
   {
-    printf("\r\n");
-    printf("unknown command\r\n");
-    printf("\r\n");
+    xil_printf("\r\n");
+    xil_printf("unknown command\r\n");
+    xil_printf("\r\n");
   }
 
 }

--- a/rflan/src/zmodem/zmodem.c
+++ b/rflan/src/zmodem/zmodem.c
@@ -117,9 +117,9 @@ static void ZModem_CliZmodem(Cli_t *CliInstance, const char *cmd, void *userData
   else if (strcmp(operation, "status") == 0)
   {
     printf("-------------------------------\r\n");
-    printf("ZMODEM\r\n");
+    printf("            ZMODEM             \r\n");
     printf("-------------------------------\r\n");
-    printf("Module state         : %s\r\n", (zmodem_ctrl.run ? "enabled" : "disabled"));
+    printf("Module state         : %s\r\n", (zmodem_ctrl.run ? "enabled(1)" : "disabled(0)"));
     printf("Last operation \r\n");
     printf("    file name        : %s\r\n", zmodem_ctrl.instance.Stats.FileName);
     printf("    file size        : %ld\r\n", zmodem_ctrl.instance.Stats.FileSize);


### PR DESCRIPTION
a) ZMODEM is disabled by default. The terminal file transfer will enable it before the transfer.
b) ZMODEM CLI use xil_printf instead of printf
